### PR TITLE
made if_stage take one CC to respond instead of 2

### DIFF
--- a/src/CPU/if_stage.vhd
+++ b/src/CPU/if_stage.vhd
@@ -51,14 +51,12 @@ BEGIN
 		WAITrequest => open
     );
 
+    pc <= new_addr;
+    m_addr <= to_integer(unsigned(pc))/4;
     fetch_process : process(clock)
     BEGIN
-        if(rising_edge(clock)) then
-            if(pc_en = '1') then
-                pc <= new_addr;
-                q_new_addr <= std_logic_vector(unsigned(pc) + 4); -- increment pc by 4
-            end if;
+        if(pc_en = '1') then
+            q_new_addr <= std_logic_vector(unsigned(pc) + 4); -- increment pc by 4
         end if;
-        m_addr <= to_integer(unsigned(pc))/4;
     END process;
 END fetch;


### PR DESCRIPTION
Currently IF takes two clock cycles to produce the next instruction when the following signals are set

- `pc_en <= '1';`
- `new_addr <= q_new_addr;`

I believe this is because of the delay in updating pc and the delay in memory that cause this. I propose removing the delay in updating pc.

Additionally, delay will be introduced by using the pipeline register to connect `pc`to `pc+4` will cause more problems.